### PR TITLE
run update to make sure we are at latest packages

### DIFF
--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -54,4 +54,6 @@ COPY LICENSE /licenses
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
+RUN microdnf update -y && microdnf clean all
+
 USER ${USER_UID}

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -54,4 +54,6 @@ COPY LICENSE /licenses
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
+RUN microdnf update -y && microdnf clean all
+
 USER ${USER_UID}


### PR DESCRIPTION
#52 

Instead of basing of latest, we will add a microdnf update to get latest packages since we need to specify a specific sha for s390x and ppc64le