### PR TITLE
make mongodb use its own service account

### DIFF
--- a/deploy/olm-catalog/ibm-mongodb-operator/1.0.0/ibm-mongodb-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-mongodb-operator/1.0.0/ibm-mongodb-operator.v1.0.0.clusterserviceversion.yaml
@@ -157,6 +157,7 @@ spec:
           - pods
           - services
           - services/finalizers
+          - serviceaccounts
           - endpoints
           - persistentvolumeclaims
           - events

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -10,6 +10,7 @@ rules:
   - pods
   - services
   - services/finalizers
+  - serviceaccounts
   - endpoints
   - persistentvolumeclaims
   - events

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -127,6 +127,11 @@ func (r *ReconcileMongoDB) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
+	log.Info("creating mongodb service account")
+	if err := r.createFromYaml(instance, []byte(mongoSA)); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	log.Info("creating mongodb service")
 	if err := r.createFromYaml(instance, []byte(service)); err != nil {
 		return reconcile.Result{}, err
@@ -136,8 +141,6 @@ func (r *ReconcileMongoDB) Reconcile(request reconcile.Request) (reconcile.Resul
 	if err := r.createFromYaml(instance, []byte(icpService)); err != nil {
 		return reconcile.Result{}, err
 	}
-
-	log.Info("creating icp mongodb Security Context Constraints")
 
 	metadatalabel := map[string]string{"app.kubernetes.io/name": "icp-mongodb", "app.kubernetes.io/component": "database",
 		"app.kubernetes.io/managed-by": "operator", "app.kubernetes.io/instance": "icp-mongodb", "release": "mongodb"}

--- a/pkg/controller/mongodb/service_account.go
+++ b/pkg/controller/mongodb/service_account.go
@@ -1,0 +1,23 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package mongodb
+
+const mongoSA = `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ibm-mongodb-operand
+`

--- a/pkg/controller/mongodb/statefulset.go
+++ b/pkg/controller/mongodb/statefulset.go
@@ -47,8 +47,7 @@ spec:
         prometheus.io/port: "9216"
         prometheus.io/path: "/metrics"
     spec:
-      securityContext:
-        runAsUser: 1000570000
+      serviceAccountName: ibm-mongodb-operand
       terminationGracePeriodSeconds: 30
       hostNetwork: false
       hostPID: false


### PR DESCRIPTION
MongoDB uses a share service account(the name is `default`) before, but this service account is used by multiple services and assigned multiple permissions. Some of the permissions conflict with mongodb.

This fix is used to create a service account that only used by mongodb, this can avoid permission conflicts.