### PR TITLE
remove release version image tag and push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,6 @@ ifeq ($(LOCAL_ARCH),x86_64)
 	@chmod +x /tmp/manifest-tool
 	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG) --ignore-missing
 	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG):$(VERSION) --ignore-missing
-	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG):$(CSV_VERSION) --ignore-missing
 endif
 endif
 


### PR DESCRIPTION
ONLY tagging with the git commit sha to ensure we do not unintentionally overwrite any of the released operators with an updated copy.