### PR TITLE
Revert dns

### DIFF
--- a/pkg/controller/mongodb/certificate.go
+++ b/pkg/controller/mongodb/certificate.go
@@ -86,6 +86,5 @@ spec:
   commonName: "mongodb-service"
   dnsNames:
   - mongodb
-  - mongodb.ibm-common-services
-  - mongodb.ibm-common-services.svc
+  - mongodb.ibm-common-services.svc.cluster.local
 `

--- a/pkg/controller/mongodb/certificate.go
+++ b/pkg/controller/mongodb/certificate.go
@@ -21,7 +21,7 @@ kind: Issuer
 metadata:
   name: god-issuer
   namespace: ibm-common-services
-  labels:
+  labels: 
     app.kubernetes.io/instance: mongodbs.operator.ibm.com
     app.kubernetes.io/managed-by: mongodbs.operator.ibm.com
     app.kubernetes.io/name: mongodbs.operator.ibm.com
@@ -35,7 +35,7 @@ kind: Certificate
 metadata:
   name: mongodb-root-ca-cert
   namespace: ibm-common-services
-  labels:
+  labels: 
     app.kubernetes.io/instance: mongodbs.operator.ibm.com
     app.kubernetes.io/managed-by: mongodbs.operator.ibm.com
     app.kubernetes.io/name: mongodbs.operator.ibm.com
@@ -57,7 +57,7 @@ kind: Issuer
 metadata:
   name: mongodb-root-ca-issuer
   namespace: ibm-common-services
-  labels:
+  labels: 
     app.kubernetes.io/instance: mongodbs.operator.ibm.com
     app.kubernetes.io/managed-by: mongodbs.operator.ibm.com
     app.kubernetes.io/name: mongodbs.operator.ibm.com
@@ -72,7 +72,7 @@ kind: Certificate
 metadata:
   name: icp-mongodb-client-cert
   namespace: ibm-common-services
-  labels:
+  labels: 
     app.kubernetes.io/instance: mongodbs.operator.ibm.com
     app.kubernetes.io/managed-by: mongodbs.operator.ibm.com
     app.kubernetes.io/name: mongodbs.operator.ibm.com
@@ -86,5 +86,4 @@ spec:
   commonName: "mongodb-service"
   dnsNames:
   - mongodb
-  - mongodb.ibm-common-services.svc.cluster.local
 `

--- a/pkg/controller/mongodb/initconfigmap.go
+++ b/pkg/controller/mongodb/initconfigmap.go
@@ -158,7 +158,6 @@ data:
     DNS.4 = localhost
     DNS.5 = 127.0.0.1
     DNS.6 = mongodb
-    DNS.7 = mongodb.ibm-common-services.svc.cluster.local
     EOL
 
         # Generate the certs

--- a/pkg/controller/mongodb/initconfigmap.go
+++ b/pkg/controller/mongodb/initconfigmap.go
@@ -158,8 +158,7 @@ data:
     DNS.4 = localhost
     DNS.5 = 127.0.0.1
     DNS.6 = mongodb
-    DNS.7 = mongodb.ibm-common-services
-    DNS.8 = mongodb.ibm-common-services.svc
+    DNS.7 = mongodb.ibm-common-services.svc.cluster.local
     EOL
 
         # Generate the certs


### PR DESCRIPTION
Taylor George says MCM found another way to accomplish this task and no longer need these DNS changes, reverting the last two commits