### PR TITLE
CICD changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ NAMESPACE=ibm-common-services
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
 IMG ?= ibm-mongodb-operator
-REGISTRY ?= quay.io/opencloudio
+REGISTRY ?= "hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom"
 CSV_VERSION ?= 1.1.4
 
 QUAY_USERNAME ?=
@@ -38,8 +38,7 @@ MARKDOWN_LINT_WHITELIST=https://quay.io/cnr
 
 TESTARGS_DEFAULT := "-v"
 export TESTARGS ?= $(TESTARGS_DEFAULT)
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
-                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell cat ./version/version.go | grep "Version =" | awk '{ print $$3}' | tr -d '"')
 
 LOCAL_OS := $(shell uname)
 LOCAL_ARCH := $(shell uname -m)

--- a/common/scripts/config_docker.sh
+++ b/common/scripts/config_docker.sh
@@ -16,13 +16,12 @@
 #
 
 KUBECTL=$(command -v kubectl)
-DOCKER_REGISTRY="quay.io"
-DOCKER_USERNAME="multicloudlab"
-DOCKER_PASSWORD=$(${KUBECTL} -n default get secret quay-cred -o jsonpath='{.data.password}' | base64 --decode)
+DOCKER_REGISTRY="hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com"
+DOCKER_USERNAME=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.username}' | base64 --decode)
+DOCKER_PASSWORD=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.password}' | base64 --decode)
 
 # support other container tools, e.g. podman
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 
 # login the docker registry
 ${CONTAINER_CLI} login "${DOCKER_REGISTRY}" -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
-


### PR DESCRIPTION
CICD Changes 

# Integrating Operator Images

For operator images, the builds should be able to remain largely unchanged, we just need to change where the images are pushed once they are built, and pull in the credentials needed to push to Artifactory.  We are also going to go back to pushing with the final image version tag since we are pushing to Artifactory first, CICD will maintain multiple image versions in our test repo to avoid breaking builds by tagging images both with the release version tag, and with a datestamp tag when they are newly promoted.

There are basically 3 updates that need to happen in your operator repo:

#### 1. Update the `common/scripts/config_docker.sh` script to get Artifactory credentials and log into artifactory.
There should be an existing section in this file that looks like this:
```
DOCKER_REGISTRY="quay.io"
DOCKER_USERNAME="multicloudlab"
DOCKER_PASSWORD=$(${KUBECTL} -n default get secret quay-cred -o jsonpath='{.data.password}' | base64 --decode)
```
You will instead replace it with these lines:
```
DOCKER_REGISTRY="hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com"
DOCKER_USERNAME=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.username}' | base64 --decode)
DOCKER_PASSWORD=$(${KUBECTL} -n default get secret artifactory-cred -o jsonpath='{.data.password}' | base64 --decode)
```

#### 2. Update the registry defined in your `Makefile` 
There is a line in the `Makefile` that sets `quay.io` as the registry to push images to:
```
REGISTRY ?= quay.io/opencloudio
```
You will instead replace it with integration:
```
REGISTRY ?= "hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom"
```

#### 3. Update the `VERSION` variable defined in your Makefile
Most operators are setting a `VERSION` variable using the git commit, and pushing the image tagged with that value using a statement similar to this:
```
VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
```
For go operators, you can use this line instead to fetch the `Version` variable from your version.go (the same place cicd will fetch it to decide what tag to pick up, that way you only have to update one location to switch to a new image tag):
```
VERSION ?= $(shell cat ./version/version.go | grep "Version =" | awk '{ print $$3}' | tr -d '"')
```