### PR TITLE
Increase liveness

### DIFF
--- a/pkg/controller/mongodb/statefulset.go
+++ b/pkg/controller/mongodb/statefulset.go
@@ -310,11 +310,11 @@ spec:
                   --mongodb.tls-ca=/data/configdb/tls.crt
                   --mongodb.tls-cert=/work-dir/mongo.pem
                   --test
-              initialDelaySeconds: 30
-              timeoutSeconds: 10
-              failureThreshold: 10
-              periodSeconds: 30
-              successThreshold: 1
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 10
+            periodSeconds: 30
+            successThreshold: 1
       tolerations:
         - effect: NoSchedule
           key: dedicated

--- a/pkg/controller/mongodb/statefulset.go
+++ b/pkg/controller/mongodb/statefulset.go
@@ -210,7 +210,7 @@ spec:
                 - "db.adminCommand('ping')"
             initialDelaySeconds: 30
             timeoutSeconds: 10
-            failureThreshold: 10
+            failureThreshold: 5
             periodSeconds: 30
             successThreshold: 1
           readinessProbe:
@@ -314,6 +314,7 @@ spec:
               timeoutSeconds: 10
               failureThreshold: 10
               periodSeconds: 30
+              successThreshold: 1
       tolerations:
         - effect: NoSchedule
           key: dedicated

--- a/pkg/controller/mongodb/statefulset.go
+++ b/pkg/controller/mongodb/statefulset.go
@@ -209,9 +209,9 @@ spec:
                 - --eval
                 - "db.adminCommand('ping')"
             initialDelaySeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
-            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 10
+            periodSeconds: 30
             successThreshold: 1
           readinessProbe:
             exec:
@@ -310,8 +310,10 @@ spec:
                   --mongodb.tls-ca=/data/configdb/tls.crt
                   --mongodb.tls-cert=/work-dir/mongo.pem
                   --test
-            initialDelaySeconds: 30
-            periodSeconds: 10
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 10
+              periodSeconds: 30
       tolerations:
         - effect: NoSchedule
           key: dedicated


### PR DESCRIPTION
```
    Liveness:   exec [sh -ec /bin/mongodb_exporter --mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:27017 --mongodb.tls --mongodb.tls-ca=/data/configdb/tls.crt --mongodb.tls-cert=/work-dir/mongo.pem --test] delay=30s timeout=10s period=30s #success=1 #failure=10
```
```
Liveness:   exec [mongo --ssl --sslCAFile=/data/configdb/tls.crt --sslPEMKeyFile=/work-dir/mongo.pem --eval db.adminCommand('ping')] delay=30s timeout=10s period=30s #success=1 #failure=5
```

This is to help prevent the metrics container taking down the mongoDB container too quickly when MongoDB may be able to recover on its own. It also fixes a new rule from IBM Certification making the liveness probe total time to failure longer than the readiness probe